### PR TITLE
Replace bitwise operations with fixed constant

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -238,10 +238,8 @@ function generate_messages(live_chat_json)
                     elseif action.addChatItemAction.item.liveChatPaidMessageRenderer then
                         local liveChatPaidMessageRenderer = action.addChatItemAction.item.liveChatPaidMessageRenderer
 
-                        local border_color = liveChatPaidMessageRenderer.bodyBackgroundColor
-                        border_color = bit32.band(border_color, bit32.lshift(1, 24) - 1)
-                        local text_color = liveChatPaidMessageRenderer.bodyTextColor
-                        text_color = bit32.band(text_color, bit32.lshift(1, 24) - 1)
+                        local border_color = liveChatPaidMessageRenderer.bodyBackgroundColor - 0xff000000
+                        local text_color = liveChatPaidMessageRenderer.bodyTextColor - 0xff000000
                         local money = liveChatPaidMessageRenderer.purchaseAmountText.simpleText
 
                         local author


### PR DESCRIPTION
bit32 is only available in lua 5.2, with lua 5.3 providing [native support for bitwise operators](http://lua-users.org/wiki/BitwiseOperators)

[mpv's official windows builds by shinchiro](https://sourceforge.net/projects/mpv-player-windows) are all built with 5.1 which has neither, so just use a fixed constant since we don't need to compute it every time anyway

only tested on windows, mpv version 0.35.0-385, lua 5.1

see also #2 